### PR TITLE
Add refresh token to cookies on refresh.

### DIFF
--- a/server/src/routes/auth.route.ts
+++ b/server/src/routes/auth.route.ts
@@ -4,6 +4,7 @@ import UserModel from "../models/user.model";
 import {
     clearAuthCookies,
     getAccessTokenCookieOptions,
+    getRefreshTokenCookieOptions,
     setAuthCookies,
 } from "../utils/cookies";
 
@@ -109,11 +110,11 @@ authRoutes.post("/register", async (req, res) => {
 
 // -- REFRESH TOKEN HANDLER --
 authRoutes.get("/refresh", async (req, res) => {
-    const cookieToken = req.cookies.refreshToken;
+    // const cookieToken = req.cookies.refreshToken;
     const authHeader = req.headers["authorization"];
     const refreshToken = authHeader && authHeader.split(" ")[1];
-    if (cookieToken == null) return res.sendStatus(401); // No token provided
-    if (!refreshTokens.includes(cookieToken)) return res.sendStatus(403); // Invalid token
+    // if (cookieToken == null) return res.sendStatus(401); // No token provided
+    if (!refreshTokens.includes(refreshToken || "")) return res.sendStatus(403); // Invalid token
     jwt.verify(refreshToken, JWT_REFRESH_SECRET, (err: any, user: any) => {
         if (err) return res.sendStatus(403); // Invalid token
         const session_user = { id: user.id, email: user.email };
@@ -122,7 +123,7 @@ authRoutes.get("/refresh", async (req, res) => {
             "accessToken",
             accessToken,
             getAccessTokenCookieOptions()
-        ).json({ accessToken: accessToken });
+        ).cookie('refreshToken', refreshToken, getRefreshTokenCookieOptions()).json({ accessToken: accessToken });
     });
 });
 

--- a/server/src/utils/cookies.ts
+++ b/server/src/utils/cookies.ts
@@ -9,8 +9,8 @@ const defaults: CookieOptions = {
     secure
 }
 
-export const getAccessTokenCookieOptions = (): CookieOptions => ({...defaults, expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)})
-export const getRefreshTokenCookieOptions = (): CookieOptions => ({...defaults, expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)})
+export const getAccessTokenCookieOptions = (): CookieOptions => ({...defaults, expires: new Date(Date.now() + 15 * 1000)}) // 15 s
+export const getRefreshTokenCookieOptions = (): CookieOptions => ({...defaults, expires: new Date(Date.now() + 30 * 60 * 1000)}) // 30 m
 
 type Params = {
     res: Response,
@@ -23,7 +23,7 @@ export const setAuthCookies = ({res, accessToken, refreshToken, rememberMe}: Par
     if (rememberMe) {
         res.cookie("refreshToken", refreshToken, getAccessTokenCookieOptions())
     }
-    res.cookie("accessToken", accessToken, getAccessTokenCookieOptions())
+    res.cookie("accessToken", accessToken, getRefreshTokenCookieOptions())
     return res
 }
 


### PR DESCRIPTION
Remember Me would not keep the user logged in longer. These code changes makes sure to update the refresh token in the cookies. 